### PR TITLE
/etc/ssh/*_key should have permission 0600

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19690,7 +19690,7 @@
 - name: Set permissions for /etc/ssh/ file(s)
   file:
     path: '{{ item.path }}'
-    mode: '0640'
+    mode: '0600'
   with_items:
   - '{{ files_found.files }}'
   when:


### PR DESCRIPTION
The private key files under /etc/ssh should not have 0640 permission.  It is too open and break SSH connection. 